### PR TITLE
Fixes #4: Don't include required field if array is empty

### DIFF
--- a/src/convert.ts
+++ b/src/convert.ts
@@ -244,11 +244,16 @@ function definitions(entitySets: Array<EntitySet>): Definitions {
 function schema(entityType: EntityType): Schema {
   const required = entityType.properties.filter(property => property.required).map(property => property.name);
 
-  return {
+  const schema: Schema = {
     type: 'object',
     properties: properties(entityType.properties),
-    required: required
   };
+
+  if (required.length > 0) {
+    schema.required = required;
+  }
+
+  return schema;
 }
 
 function properties(properties: Array<EntityProperty>): {[name: string]: Property} {


### PR DESCRIPTION
Only add `required` field to the Open API specification if it is not empty.
