### PR TITLE
Updated parse.ts

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -27,7 +27,7 @@ function parseEntitySet(namespace: string, entitySet: any, entityType: any): Ent
 function parseEntityType(entityType: any): EntityType {
   const result: EntityType = {
     name: entityType['$']['Name'],
-    properties: entityType['Property'].map(parseProperty)
+    properties: entityType['Property'] ? entityType['Property'].map(parseProperty) : []
   };
 
   const keys = entityType['Key'];


### PR DESCRIPTION
 updated parseEntityType to handle when EntityType has no Properties nodes. to handle better for example https://graph.microsoft.com/beta/$metadata