### PR TITLE
Support use of custom ports

### DIFF
--- a/src/get.ts
+++ b/src/get.ts
@@ -2,7 +2,7 @@ import * as http from 'http';
 import * as https from 'https';
 import * as url from 'url';
 
-function get(protocol, host, path): Promise<string> {
+function get(protocol, host, path, port): Promise<string> {
   return new Promise<string>((resolve, reject) => {
     const options = {
       host,
@@ -11,7 +11,8 @@ function get(protocol, host, path): Promise<string> {
         'Accept': '*/*',
         'User-Agent': 'odata2openapi'
       },
-      path
+      path,
+      port
     };
 
     const fetcher = (protocol.startsWith('https:') ? https.request : http.request);

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import parse from './parse';
 import convert from './convert';
 
 function odata2openapi(metadataUrl: string, options?: Options): Promise<Swagger> {
-  const { path, host, protocol } = url.parse(metadataUrl);
+  const { path, hostname, protocol, port } = url.parse(metadataUrl);
 
   if (!options) {
     options = {
@@ -16,7 +16,7 @@ function odata2openapi(metadataUrl: string, options?: Options): Promise<Swagger>
     };
   }
 
-  return get(protocol, host, path).then(parse).then(service => convert(service.entitySets, options, service.version))
+  return get(protocol, host, path, port).then(parse).then(service => convert(service.entitySets, options, service.version))
 }
 
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ function odata2openapi(metadataUrl: string, options?: Options): Promise<Swagger>
     };
   }
 
-  return get(protocol, host, path, port).then(parse).then(service => convert(service.entitySets, options, service.version))
+  return get(protocol, hostname, path, port).then(parse).then(service => convert(service.entitySets, options, service.version))
 }
 
 export {


### PR DESCRIPTION
url.host includes the port name, but http.request expects the port in its own options key.
fixes #12