### PR TITLE
Fix existing XML example to use Service Object

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ const options = {
 };
 
 parse(xml)
-  .then(entitySets => convert(entitySets, options))
+  .then(service => convert(service.entitySets, options, service.version))
   .then(swagger => console.log(JSON.stringify(swagger, null, 2)))
   .catch(error => console.error(error))
 ```
@@ -66,7 +66,7 @@ const options: Options = {
 const xml = '';
 
 parse(xml)
-  .then(entitySets => convert(entitySets, options))
+  .then(service => convert(service.entitySets, options, service.version))
   .then(swagger => console.log(JSON.stringify(swagger, null, 2)))
   .catch(error => console.error(error))
 ```


### PR DESCRIPTION
Running the example as-is throws an exception about the forEach method, as the result of the parse() function is a service object, not an array of entity sets.